### PR TITLE
continuum_offset /FSR for the wave regions pulled from the tuning files

### DIFF
--- a/resource/wave_regions/ucomp.1074.spec.cfg
+++ b/resource/wave_regions/ucomp.1074.spec.cfg
@@ -13,7 +13,7 @@ plate_scale                      : type=float, default=2.834
 plate_scale_tolerance            : type=float, default=0.02
 opal_radiance                    : type=float, default=14.8
 fwhm                             : type=float, default=0.138
-continuum_offset                 : type=float, default=1.25625
+continuum_offset                 : type=float, default=1.2817
 
 subtract_continuum               : type=boolean, default=YES
 create_average                   : type=boolean, default=YES

--- a/resource/wave_regions/ucomp.1079.spec.cfg
+++ b/resource/wave_regions/ucomp.1079.spec.cfg
@@ -13,7 +13,7 @@ plate_scale                      : type=float, default=2.832
 plate_scale_tolerance            : type=float, default=0.02
 opal_radiance                    : type=float, default=14.4
 fwhm                             : type=float, default=0.141
-continuum_offset                 : type=float, default=1.28025
+continuum_offset                 : type=float, default=1.2956
 
 subtract_continuum               : type=boolean, default=YES
 create_average                   : type=boolean, default=YES

--- a/resource/wave_regions/ucomp.1083.spec.cfg
+++ b/resource/wave_regions/ucomp.1083.spec.cfg
@@ -13,7 +13,7 @@ plate_scale                      : type=float, default=2.833
 plate_scale_tolerance            : type=float, default=0.02
 opal_radiance                    : type=float, default=14.0
 fwhm                             : type=float, default=0.142
-continuum_offset                 : type=float, default=1.28775
+continuum_offset                 : type=float, default=1.30442
 
 subtract_continuum               : type=boolean, default=NO
 create_average                   : type=boolean, default=YES

--- a/resource/wave_regions/ucomp.530.spec.cfg
+++ b/resource/wave_regions/ucomp.530.spec.cfg
@@ -15,7 +15,7 @@ plate_scale                      : type=float, default=2.960
 plate_scale_tolerance            : type=float, default=0.02
 opal_radiance                    : type=float, default=10.8
 fwhm                             : type=float, default=0.022
-continuum_offset                 : type=float, default=0.20325
+continuum_offset                 : type=float, default=0.20858
 
 subtract_continuum               : type=boolean, default=YES
 create_average                   : type=boolean, default=YES

--- a/resource/wave_regions/ucomp.637.spec.cfg
+++ b/resource/wave_regions/ucomp.637.spec.cfg
@@ -13,7 +13,7 @@ plate_scale                      : type=float, default=2.95
 plate_scale_tolerance            : type=float, default=0.02
 opal_radiance                    : type=float, default=12.7
 fwhm                             : type=float, default=0.039
-continuum_offset                 : type=float, default=0.351
+continuum_offset                 : type=float, default=0.36108
 
 subtract_continuum               : type=boolean, default=YES
 create_average                   : type=boolean, default=YES

--- a/resource/wave_regions/ucomp.656.spec.cfg
+++ b/resource/wave_regions/ucomp.656.spec.cfg
@@ -13,7 +13,7 @@ plate_scale                      : type=float, default=2.933
 plate_scale_tolerance            : type=float, default=0.02
 opal_radiance                    : type=float, default=12.8
 fwhm                             : type=float, default=0.042
-continuum_offset                 : type=float, default=0.3795
+continuum_offset                 : type=float, default=0.39158
 
 subtract_continuum               : type=boolean, default=NO
 create_average                   : type=boolean, default=YES

--- a/resource/wave_regions/ucomp.670.spec.cfg
+++ b/resource/wave_regions/ucomp.670.spec.cfg
@@ -14,7 +14,7 @@ plate_scale                      : type=float, default=2.93
 plate_scale_tolerance            : type=float, default=0.02
 opal_radiance                    : type=float, default=12.9
 fwhm                             : type=float, default=0.044
-continuum_offset                 : type=float, default=0.39775
+continuum_offset                 : type=float, default=0.40774
 
 subtract_continuum               : type=boolean, default=YES
 create_average                   : type=boolean, default=YES

--- a/resource/wave_regions/ucomp.691.spec.cfg
+++ b/resource/wave_regions/ucomp.691.spec.cfg
@@ -13,7 +13,7 @@ plate_scale                      : type=float, default=2.934
 plate_scale_tolerance            : type=float, default=0.02
 opal_radiance                    : type=float, default=12.9
 fwhm                             : type=float, default=0.048
-continuum_offset                 : type=float, default=0.43725
+continuum_offset                 : type=float, default=0.44493
 
 subtract_continuum               : type=boolean, default=YES
 create_average                   : type=boolean, default=YES

--- a/resource/wave_regions/ucomp.706.spec.cfg
+++ b/resource/wave_regions/ucomp.706.spec.cfg
@@ -13,7 +13,7 @@ plate_scale                      : type=float, default=2.929
 plate_scale_tolerance            : type=float, default=0.02
 opal_radiance                    : type=float, default=12.8
 fwhm                             : type=float, default=0.051
-continuum_offset                 : type=float, default=0.46175
+continuum_offset                 : type=float, default=0.46943
 
 subtract_continuum               : type=boolean, default=YES
 create_average                   : type=boolean, default=YES

--- a/resource/wave_regions/ucomp.761.spec.cfg
+++ b/resource/wave_regions/ucomp.761.spec.cfg
@@ -14,7 +14,7 @@ plate_scale                      : type=float, default=2.90
 plate_scale_tolerance            : type=float, default=0.02
 opal_radiance                    : type=float, default=13.5
 fwhm                             : type=float, default=0.061
-continuum_offset                 : type=float, default=0.553
+continuum_offset                 : type=float, default=0.56677
 
 subtract_continuum               : type=boolean, default=YES
 create_average                   : type=boolean, default=YES

--- a/resource/wave_regions/ucomp.789.spec.cfg
+++ b/resource/wave_regions/ucomp.789.spec.cfg
@@ -13,7 +13,7 @@ plate_scale                      : type=float, default=2.902
 plate_scale_tolerance            : type=float, default=0.02
 opal_radiance                    : type=float, default=13.5
 fwhm                             : type=float, default=0.068
-continuum_offset                 : type=float, default=0.6125
+continuum_offset                 : type=float, default=0.62299
 
 subtract_continuum               : type=boolean, default=YES
 create_average                   : type=boolean, default=YES

--- a/resource/wave_regions/ucomp.802.spec.cfg
+++ b/resource/wave_regions/ucomp.802.spec.cfg
@@ -14,7 +14,7 @@ plate_scale                      : type=float, default=2.90
 plate_scale_tolerance            : type=float, default=0.02
 opal_radiance                    : type=float, default=13.5
 fwhm                             : type=float, default=0.069
-continuum_offset                 : type=float, default=0.63025
+continuum_offset                 : type=float, default=0.64610
 
 subtract_continuum               : type=boolean, default=YES
 create_average                   : type=boolean, default=YES

--- a/resource/wave_regions/ucomp.991.spec.cfg
+++ b/resource/wave_regions/ucomp.991.spec.cfg
@@ -14,7 +14,7 @@ plate_scale                      : type=float, default=2.82
 plate_scale_tolerance            : type=float, default=0.02
 opal_radiance                    : type=float, default=14.8
 fwhm                             : type=float, default=0.114
-continuum_offset                 : type=float, default=1.036
+continuum_offset                 : type=float, default=1.0679
 
 subtract_continuum               : type=boolean, default=YES
 create_average                   : type=boolean, default=YES


### PR DESCRIPTION
#292
The continuum_offset offset for the 13 wave regions has been updated to the period of stage0 in the tuning files found in: https://github.com/NCAR/ucomp-configuration/tree/main/config

The same number of significant digits 5 was kept from the old continuum_offset values based on the ucomp line spread sheets.